### PR TITLE
build(docker): improve build time and efficiency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
 
 WORKDIR /home/node/app
 
-COPY package*.json ./
-
 USER node
 
-COPY --chown=node:node . .
+COPY --chown=node:node package*.json ./
 
 RUN npm install
+
+COPY --chown=node:node . .
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
Install dependency before copying code

Add .env and node_modules to .dockerignore